### PR TITLE
Add some more clippy ignores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
         - cargo build --verbose
         - cargo test --verbose
         - cargo fmt --all -- --check
-        - cargo +stable clippy --all-targets --all-features -- -D warnings -A clippy::unreadable_literal -A clippy::needless_range_loop -A clippy::float_cmp
+        - cargo +stable clippy --all-targets --all-features -- -D warnings -A clippy::unreadable_literal -A clippy::needless_range_loop -A clippy::float_cmp -A clippy::comparison-chain -A clippy::needless-doctest-main -A clippy::missing-safety-doc
     - stage: test
       os: osx
       before_script:
@@ -25,7 +25,7 @@ jobs:
         - cargo build --verbose
         - cargo test --verbose
         - cargo fmt --all -- --check
-        - cargo +stable clippy --all-targets --all-features -- -D warnings -A clippy::unreadable_literal -A clippy::needless_range_loop -A clippy::float_cmp
+        - cargo +stable clippy --all-targets --all-features -- -D warnings -A clippy::unreadable_literal -A clippy::needless_range_loop -A clippy::float_cmp -A clippy::comparison-chain -A clippy::needless-doctest-main -A clippy::missing-safety-doc
         
     # deploy crates and documentation conditionally
     # deploy on cargo if tagged master release

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ pub fn main<T: Plugin + Default>(callback: HostCallbackProc) -> *mut AEffect {
 
     trace!("Creating VST plugin instance...");
     let mut plugin = T::new(host);
-    let info = plugin.get_info().clone();
+    let info = plugin.get_info();
     let params = plugin.get_parameter_object();
     let editor = plugin.get_editor();
 


### PR DESCRIPTION
Couldn't edit your branch directly, but these changes should fix the clippy issues.

 - `clippy::needless-doctest-main` is a false positive in our case, since we need it for the doctests to compile, so that will probably be a permanent ignore.
 - `clippy::comparison-chain` is a style choice that I don't feel it's necessary to enforce here, so that will probably be a permanent ignore.
 - `clippy::missing-safety-doc` is something we should fix eventually, so this will be a temporary ignore. I'll make an issue for it in the `vst-rs` repo after this PR is merged.